### PR TITLE
Use ADMIN_TOKEN env var with secure token checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # paws.ovh
+
+## Deployment
+
+Set the environment variable `ADMIN_TOKEN` to a secret value before running the application. This token is required for upload and delete operations.
+
+```bash
+export ADMIN_TOKEN="your-secret-token"
+```

--- a/config.php
+++ b/config.php
@@ -2,7 +2,7 @@
 // config.php
 
 define('UPLOAD_FOLDER', __DIR__ . '/public');
-define('ADMIN_TOKEN', 'TEST');
+define('ADMIN_TOKEN', getenv('ADMIN_TOKEN') ?: '');
 define('MAX_FILE_SIZE', 10 * 1024 * 1024);
 
 function getAlphabet(): array

--- a/delete.php
+++ b/delete.php
@@ -23,7 +23,7 @@ $filename = $_POST['filename'];
 $token = $_POST['token'];
 
 // Vérifier que le token est valide
-if ($token !== ADMIN_TOKEN) {
+if (!hash_equals(ADMIN_TOKEN, $token)) {
     http_response_code(403);
     exit('Token invalide');
 }

--- a/upload.php
+++ b/upload.php
@@ -17,7 +17,7 @@ if (!isset($_FILES['file'])) {
 }
 
 $token = $_POST['token'] ?? '';
-if ($token !== ADMIN_TOKEN) {
+if (!hash_equals(ADMIN_TOKEN, $token)) {
     http_response_code(403);
     exit('Token invalide');
 }


### PR DESCRIPTION
## Summary
- load `ADMIN_TOKEN` from environment with empty default
- verify admin tokens with `hash_equals`
- document `ADMIN_TOKEN` deployment variable

## Testing
- `php -l config.php`
- `php -l upload.php`
- `php -l delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68a38bcd2ef88322825652e827309cd6