### PR TITLE
Sanitize filename and validate extension on delete

### DIFF
--- a/delete.php
+++ b/delete.php
@@ -19,8 +19,15 @@ if (!isset($_POST['filename']) || !isset($_POST['token'])) {
     exit('Paramètres manquants');
 }
 
-$filename = $_POST['filename'];
+$filename = basename($_POST['filename']);
 $token = $_POST['token'];
+
+$allowedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+$fileExtension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+if (!in_array($fileExtension, $allowedExtensions)) {
+    http_response_code(400);
+    exit('Extension non autorisée');
+}
 
 // Vérifier que le token est valide
 if ($token !== ADMIN_TOKEN) {


### PR DESCRIPTION
## Summary
- Sanitize delete filename using `basename`
- Check allowed image extensions before building delete path

## Testing
- `php -l delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68a38be18ca08322b146bc4e8978756b