### PR TITLE
Add CSRF protection

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,6 +5,22 @@ define('UPLOAD_FOLDER', __DIR__ . '/public');
 define('ADMIN_TOKEN', 'TEST');
 define('MAX_FILE_SIZE', 10 * 1024 * 1024);
 
+// Start session for CSRF protection
+session_start();
+
+function getCsrfToken(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verifyCsrfToken(string $token): bool
+{
+    return hash_equals($_SESSION['csrf_token'] ?? '', $token);
+}
+
 function getAlphabet(): array
 {
     return array_merge(range('A', 'Z'), ['*', 'TOP']);

--- a/delete.php
+++ b/delete.php
@@ -13,14 +13,20 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit('Méthode non autorisée');
 }
 
-// Vérifier si le paramètre `filename` et `token` sont envoyés dans le formulaire
-if (!isset($_POST['filename']) || !isset($_POST['token'])) {
+// Vérifier si les paramètres requis sont envoyés dans le formulaire
+if (!isset($_POST['filename']) || !isset($_POST['token']) || !isset($_POST['csrf_token'])) {
     http_response_code(400);
     exit('Paramètres manquants');
 }
 
 $filename = $_POST['filename'];
 $token = $_POST['token'];
+$csrfToken = $_POST['csrf_token'];
+
+if (!verifyCsrfToken($csrfToken)) {
+    http_response_code(403);
+    exit('Token CSRF invalide');
+}
 
 // Vérifier que le token est valide
 if ($token !== ADMIN_TOKEN) {

--- a/src/pages/admin.php
+++ b/src/pages/admin.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../config.php';
 $letter = strtoupper($_GET['letter'] ?? 'TOP');
 $search = trim($_GET['search'] ?? '');
 $token = $_GET['token'] ?? '';
+$csrfToken = getCsrfToken();
 $images = getImages($letter, $search);
 $alphabet = getAlphabet();
 $totalImages = count($images);
@@ -45,6 +46,7 @@ $totalImages = count($images);
             <input type="hidden" name="letter" value="<?= htmlspecialchars($letter) ?>">
             <input type="file" name="file" required><br><br>
             <input type="hidden" name="token" value="<?= htmlspecialchars($token) ?>">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
             <button type="submit">Téléverser</button>
         </form>
         <h2 class="content-title">Gestion de la galerie</h2>
@@ -82,6 +84,7 @@ $totalImages = count($images);
                     <form method="POST" action="/delete.php" onsubmit="return confirm('Supprimer <?= htmlspecialchars($img['username']) ?>.png ?');">
                         <input type="hidden" name="filename" value="<?= htmlspecialchars($img['username']) ?>.png">
                         <input type="hidden" name="token" value="<?= htmlspecialchars($token) ?>">
+                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
                         <button type="submit" class="btn-upload">Supprimer</button>
                     </form>
                 </div>

--- a/src/pages/index.php
+++ b/src/pages/index.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../config.php';
 
 $letter = strtoupper($_GET['letter'] ?? 'TOP');
 $search = trim($_GET['search'] ?? '');
+$csrfToken = getCsrfToken();
 $images = getImages($letter, $search);
 $alphabet = getAlphabet();
 $totalImages = count($images);
@@ -88,6 +89,7 @@ $totalImages = count($images);
     </footer>
 
     <script>
+        const csrfToken = '<?= $csrfToken ?>';
         function openModal(username) {
             const modal = document.getElementById('imageModal');
             const modalImg = document.getElementById('modalImage');
@@ -112,7 +114,8 @@ $totalImages = count($images);
                     },
                     body: JSON.stringify({
                         username,
-                        direction
+                        direction,
+                        csrf_token: csrfToken
                     })
                 })
                 .then(res => res.json())

--- a/src/pages/vote-gallery.php
+++ b/src/pages/vote-gallery.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../config.php';
+$csrfToken = getCsrfToken();
 $image = getNextUnvotedImage();
 ?>
 <!DOCTYPE html>
@@ -58,6 +59,7 @@ $image = getNextUnvotedImage();
     </div>
 
     <script>
+        const csrfToken = '<?= $csrfToken ?>';
         function submitVote(direction) {
             const username = document.getElementById('current-username').value;
 
@@ -68,7 +70,8 @@ $image = getNextUnvotedImage();
                     },
                     body: JSON.stringify({
                         username,
-                        direction
+                        direction,
+                        csrf_token: csrfToken
                     })
                 })
                 .then(res => res.json())

--- a/upload.php
+++ b/upload.php
@@ -16,6 +16,12 @@ if (!isset($_FILES['file'])) {
     exit('Aucun fichier reçu.');
 }
 
+$csrfToken = $_POST['csrf_token'] ?? '';
+if (!verifyCsrfToken($csrfToken)) {
+    http_response_code(403);
+    exit('Token CSRF invalide');
+}
+
 $token = $_POST['token'] ?? '';
 if ($token !== ADMIN_TOKEN) {
     http_response_code(403);

--- a/vote.php
+++ b/vote.php
@@ -22,6 +22,13 @@ if (json_last_error() !== JSON_ERROR_NONE) {
     exit;
 }
 
+$csrfToken = $data['csrf_token'] ?? '';
+if (!verifyCsrfToken($csrfToken)) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Invalid CSRF token']);
+    exit;
+}
+
 $username = preg_replace('/[^a-zA-Z0-9-_]/', '_', $data['username'] ?? '');
     
 $IP = $_SERVER['HTTP_CLIENT_IP']


### PR DESCRIPTION
## Summary
- Generate CSRF token stored in session
- Include CSRF token in admin forms and AJAX vote requests
- Validate CSRF token in upload, delete and vote endpoints

## Testing
- `php -l config.php && php -l src/pages/admin.php && php -l src/pages/index.php && php -l src/pages/vote-gallery.php && php -l upload.php && php -l delete.php && php -l vote.php`


------
https://chatgpt.com/codex/tasks/task_e_68a38c13af6c8322a803ca6f9b9532f7