### PR TITLE
Use standard PHP open tag in ip.php

### DIFF
--- a/ip.php
+++ b/ip.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 echo "<pre>";
 echo "REMOTE_ADDR               : " . $_SERVER['REMOTE_ADDR'] . "\n";


### PR DESCRIPTION
## Summary
- replace short open tag with full `<?php` tag to work regardless of `short_open_tag`

## Testing
- `php -l ip.php`
- `REMOTE_ADDR=1.2.3.4 HTTP_CF_CONNECTING_IP=5.6.7.8 HTTP_X_FORWARDED_FOR=9.8.7.6 php -d short_open_tag=0 ip.php`

------
https://chatgpt.com/codex/tasks/task_e_68a38c1b990c8322816f1541c672de7f