### PR TITLE
Protect sensitive files via .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,3 +4,15 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]
+
+<Files "votes.json">
+    Require all denied
+</Files>
+
+<Files "config.php">
+    Require all denied
+</Files>
+
+<FilesMatch "\.ini$">
+    Require all denied
+</FilesMatch>


### PR DESCRIPTION
## Summary
- Block direct access to sensitive files like votes.json and config.php via .htaccess
- Deny access to any *.ini files using an Apache FilesMatch rule

## Testing
- `php -l config.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a38d2e90348322b998346d9c6405c3