### PR TITLE
Force HTTPS redirect in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,6 @@
 RewriteEngine On
+RewriteCond %{HTTPS} !=on
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 RewriteBase /
 
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
## Summary
- redirect all HTTP traffic to HTTPS before other rewrite rules

## Testing
- `php -l $(find . -name '*.php')`
- `apache2ctl -t` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a38d2ee36483228145d0346b8b9165