### PR TITLE
Enforce secure session cookie settings

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -1,2 +1,6 @@
 upload_max_filesize = 10M
 post_max_size = 10M
+session.cookie_httponly = 1
+session.cookie_secure = 1
+session.cookie_samesite = Strict
+session.use_strict_mode = 1


### PR DESCRIPTION
## Summary
- Harden session handling by enabling secure, HTTP-only, strict-mode cookies with a Strict SameSite policy

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a38d3266a883229e41891fefe0b37c