### PR TITLE
Configure PHP error handling

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,5 @@
+; Custom PHP configuration for paws.ovh
+expose_php = Off
+display_errors = Off
+log_errors = On
+error_log = /var/log/paws/php_errors.log


### PR DESCRIPTION
## Summary
- disable exposing PHP version and displaying runtime errors
- enable error logging to a secure location

## Testing
- `php -c php.ini -i | grep -E "(expose_php|display_errors|log_errors|error_log)"`


------
https://chatgpt.com/codex/tasks/task_e_68a38d32ad408322a413e3455e1847fc