### PR TITLE
Restrict HTTP methods in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,9 @@
 RewriteEngine On
 RewriteBase /
 
+RewriteCond %{REQUEST_METHOD} !^(GET|POST|HEAD)$ [NC]
+RewriteRule .* - [F,L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]


### PR DESCRIPTION
## Summary
- Allow only GET, POST and HEAD HTTP methods by default

## Testing
- `php -l index.php delete.php ip.php list.php upload.php vote.php config.php`

------
https://chatgpt.com/codex/tasks/task_e_68a38d2fd5d08322bffcc86e3ee8d263